### PR TITLE
fix console log missing config for inactive pairs

### DIFF
--- a/marketmaker.js
+++ b/marketmaker.js
@@ -458,7 +458,9 @@ async function sendOrders(pairs = MM_CONFIG.pairs) {
   for (const marketId in pairs) {
     const mmConfig = pairs[marketId];
     if (!mmConfig || !mmConfig.active) {
-      console.error(`Missing mmConfig for sendOrders ${marketId}`);
+      if(!mmConfig) {
+        console.error(`Missing mmConfig for sendOrders ${marketId}`);
+      }
       continue;
     }
 


### PR DESCRIPTION
 if mm config contains inactive pairs, original code will produce "missing mmConfig" console log for those inactive pair and flood the screen